### PR TITLE
Scoped structures in macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 <img src="misc/logo-gray.svg" width="400" />
 
 # BeCauSe
-## The Basic like, Compiled, Stack based language
+
+## The Because, Compiled, Stack based language
 
 B basic like<br />
 C Compiled<br />
 S Simple
 
-Its like forth, its like basic, it has modern syntax. what alse would you ask from a language?
+Because is a self hostedm concatenative, stack based programming language. What
+else would you ask from an awesome programming language?
 
 ---
 
 ## Install
+
 Currently, BeCauSe can only be installed on Linux operating systems due to the fact it uses Nasm and other commands that are only availabe on Linux.
 
 To install BeCauSe, make sure to have ./bcs.py in your path
@@ -19,18 +22,22 @@ To install BeCauSe, make sure to have ./bcs.py in your path
 ---
 
 ## Quick start
+
 Interpreting
+
 ```console
 $ python3 ./bcs.py run examples/e006_while_loops.bcs
 ```
 
 Compiling
+
 ```console
 $ python3 ./bcs.py com examples/e006_while_loops.bcs
 $ ./output
 ```
 
 Keeping the generated assembly
+
 ```console
 $ python3 ./bcs.py com examples/e006_while_loops.bcs debug
 $ cat ./output.asm

--- a/src/modules/opcodes.py
+++ b/src/modules/opcodes.py
@@ -1,4 +1,5 @@
 instructions_map = {}
+scoped_instructions = []
 
 MEMORY_CAPACITY = 640_000
 STRING_CAPACITY = 640_000
@@ -6,21 +7,22 @@ STRING_CAPACITY = 640_000
 iota_counter = 0
 
 
-def register_operation(name, reset=False):
+def register_operation(name, scoped=False):
     global iota_counter
-    if reset:
-        iota_counter = 0
     result = iota_counter
     iota_counter += 1
 
     instructions_map[result] = name
+
+    if scoped:
+        scoped_instructions.append(result)
 
     return result
 
 
 class Operation:
     # Stack
-    PUSH_INT = register_operation("PUSH", True)
+    PUSH_INT = register_operation("PUSH")
     PUSH_STRING = register_operation("PUSH")
     DUP = register_operation("DUP")
     TWO_DUP = register_operation("2DUP")
@@ -61,14 +63,14 @@ class Operation:
 
 
 class Keyword:
-    IF = register_operation("IF")
+    IF = register_operation("IF", scoped=True)
     END = register_operation("END")
     ELSE = register_operation("ELSE")
     WHILE = register_operation("WHILE")
-    DO = register_operation("DO")
-    MACRO = register_operation("MACRO")
+    DO = register_operation("DO", scoped=True)
+    MACRO = register_operation("MACRO", scoped=True)
     IMPORT = register_operation("IMPORT")
-    MEMORY = register_operation("MEMORY")
+    MEMORY = register_operation("MEMORY", scoped=True)
 
 
 class TokenType:

--- a/src/modules/parser.py
+++ b/src/modules/parser.py
@@ -402,9 +402,6 @@ def crossreference_blocks(tokens, file_path):
             program.append(op)
             ip += 1
 
-    for i in program:
-        print(i)
-
     return program
 
 

--- a/src/modules/parser.py
+++ b/src/modules/parser.py
@@ -1,4 +1,4 @@
-from modules.opcodes import Operation, Keyword, TokenType
+from modules.opcodes import Operation, Keyword, TokenType, scoped_instructions
 
 from modules.stdlibs import stdlibs
 
@@ -46,6 +46,9 @@ BUILDIN_WORDS = {
     'import': Keyword.IMPORT,
     'memory': Keyword.MEMORY
 }
+
+scoped_building_word = list(filter(
+    lambda x: BUILDIN_WORDS[x] in scoped_instructions, BUILDIN_WORDS.keys()))
 
 
 def find_col(line, start, predicate):
@@ -190,7 +193,7 @@ def crossreference_blocks(tokens, file_path):
 
             else:
                 print(
-                    "Parse Error: end can only be used to close 'if', 'else', "
+                    "Parse Error: end can only be use to close 'if', 'else', "
                     "'do' and 'macro' blocks")
                 exit(1)
             ip += 1
@@ -306,6 +309,7 @@ def crossreference_blocks(tokens, file_path):
             memory_regions[name_of_memory_region['value']] = 0
 
         elif op['type'] == Keyword.MACRO:
+
             # Macro must be followed by a name, code and 'end'
             if len(reversed_program) == 0:
                 (file_path, row, col) = op['loc']
@@ -367,11 +371,21 @@ def crossreference_blocks(tokens, file_path):
                 'tokens': []
             }
 
+            nestingDepth = 0
             while len(reversed_program) > 0:
                 token = reversed_program.pop()
 
-                if token['type'] == TokenType.WORD and token['value'] == 'end':
-                    break
+                if (token['type'] == TokenType.WORD and
+                        token['value'] in scoped_building_word):
+                    macro['tokens'].append(token)
+                    nestingDepth += 1
+                elif (token['type'] == TokenType.WORD and
+                        token['value'] == 'end'):
+                    if nestingDepth == 0:
+                        break
+                    else:
+                        macro['tokens'].append(token)
+                        nestingDepth -= 1
                 else:
                     macro['tokens'].append(token)
 

--- a/src/modules/stdlib/io.bcs
+++ b/src/modules/stdlib/io.bcs
@@ -31,25 +31,3 @@ end
 macro IO_EXIT
     60 syscall1
 end
-
-// Usage:
-// <amount of sec> IO_SLEEP_SEC
-//
-// Example:
-// 69 IO_SLEEP_SEC
-macro IO_SLEEP_SEC
-    mem 100 + !32
-    0 mem 108 + !32
-    mem 100 + 0 swap 35 syscall2
-end
-
-// Usage:
-// <amount of ns> IO_SLEEP_NS
-//
-// Example:
-// 500000000 IO_SLEEP_NS
-macro IO_SLEEP_NS
-    0 mem 100 + !32
-    mem 108 + !32
-    mem 100 + 0 swap 35 syscall2
-end

--- a/src/modules/stdlib/io.bcs
+++ b/src/modules/stdlib/io.bcs
@@ -5,6 +5,51 @@
 // part of the BeCauSe
 // standard library
 
-macro IO_WRITE 1 1 syscall3 end
-macro IO_READ swap 0 0 syscall3 end
-macro IO_EXIT 60 syscall1 end
+// Usage:
+// <string to write> IO_WRITE
+//
+// Example:
+// "Hello world!" IO_WRITE
+macro IO_WRITE
+    1 1 syscall3
+end
+
+// Usage:
+// <memory location to store> <length of buffer> IO_READ
+//
+// Example: (store an input of length 50 at mem[100])
+// mem 100 + 50 IO_READ
+macro IO_READ
+    swap 0 0 syscall3
+end
+
+// Usage:
+// <exit code> IO_EXIT
+//
+// Example:
+// 0 IO_EXIT
+macro IO_EXIT
+    60 syscall1
+end
+
+// Usage:
+// <amount of sec> IO_SLEEP_SEC
+//
+// Example:
+// 69 IO_SLEEP_SEC
+macro IO_SLEEP_SEC
+    mem 100 + !32
+    0 mem 108 + !32
+    mem 100 + 0 swap 35 syscall2
+end
+
+// Usage:
+// <amount of ns> IO_SLEEP_NS
+//
+// Example:
+// 500000000 IO_SLEEP_NS
+macro IO_SLEEP_NS
+    0 mem 100 + !32
+    mem 108 + !32
+    mem 100 + 0 swap 35 syscall2
+end

--- a/src/modules/stdlib/time.bcs
+++ b/src/modules/stdlib/time.bcs
@@ -1,0 +1,21 @@
+// Usage:
+// <amount of sec> TIME_SLEEP_SEC
+//
+// Example:
+// 69 TIME_SLEEP_SEC
+macro TIME_SLEEP_SEC
+    mem 100 + !32
+    0 mem 108 + !32
+    mem 100 + 0 swap 35 syscall2
+end
+
+// Usage:
+// <amount of ns> TIME_SLEEP_NS
+//
+// Example:
+// 500000000 TIME_SLEEP_NS
+macro TIME_SLEEP_NS
+    0 mem 100 + !32
+    mem 108 + !32
+    mem 100 + 0 swap 35 syscall2
+end

--- a/src/modules/stdlibs.py
+++ b/src/modules/stdlibs.py
@@ -1,6 +1,6 @@
 stdlibs = {
     "std/io": open("modules/stdlib/io.bcs").read(),
-    "mem/io": open("modules/stdlib/mem.bcs").read(),
-    "sys/io": open("modules/stdlib/sys.bcs").read(),
-    "time/io": open("modules/stdlib/time.bcs").read()
+    "std/mem": open("modules/stdlib/mem.bcs").read(),
+    "std/sys": open("modules/stdlib/sys.bcs").read(),
+    "std/time": open("modules/stdlib/time.bcs").read()
 }

--- a/src/tests/_tests.json
+++ b/src/tests/_tests.json
@@ -126,7 +126,12 @@
     },
     {
         "test": "t026",
-        "expected": "6\n5\n4\n3\n2\n1\n",
+        "expected": "10\n9\n8\n7\n6\n5\n4\n3\n2\n1\nLIFTOFF!!\n",
         "description": "while in macro"
+    },
+    {
+        "test": "t027",
+        "expected": "True\nTrue\nFalse\n",
+        "description": "if/else in macro"
     }
 ]

--- a/src/tests/_tests.json
+++ b/src/tests/_tests.json
@@ -123,5 +123,10 @@
         "test": "t025",
         "expected": "12\n",
         "description": "2drop"
+    },
+    {
+        "test": "t026",
+        "expected": "6\n5\n4\n3\n2\n1\n",
+        "description": "while in macro"
     }
 ]

--- a/src/tests/t026.bcs
+++ b/src/tests/t026.bcs
@@ -1,3 +1,6 @@
+import "std/time"
+import "std/io"
+
 macro countdown
     while dup 0 > do
         dup dump
@@ -5,4 +8,5 @@ macro countdown
     end
 end
 
-6 countdown
+10 countdown
+"LIFTOFF!!\n" IO_WRITE 

--- a/src/tests/t026.bcs
+++ b/src/tests/t026.bcs
@@ -1,0 +1,8 @@
+macro countdown
+    while dup 0 > do
+        dup dump
+        1 -
+    end
+end
+
+6 countdown

--- a/src/tests/t027.bcs
+++ b/src/tests/t027.bcs
@@ -1,0 +1,13 @@
+import "std/io"
+
+macro print_bool
+    if
+        "True\n" IO_WRITE 
+    else
+        "False\n" IO_WRITE
+    end
+end
+
+5 print_bool
+1 print_bool
+0 print_bool


### PR DESCRIPTION
scoped structures like
```
while

end
```

or 

```
if

else

end
```

didnt work inside macros because macros would stop parsing as soon as it found the first end, which it shouldnt do. this is fixed now